### PR TITLE
#23 homepage button link now routes to homepage correctly

### DIFF
--- a/new_pastebin_frontend/src/app/navbar/navbar.component.html
+++ b/new_pastebin_frontend/src/app/navbar/navbar.component.html
@@ -3,7 +3,7 @@
         <nav>
             <ul>
                 <li>
-                    <a routerLink="/homepage">Home </a>
+                    <a routerLink="/">Home </a>
                 </li>
                 <li>
                     <a routerLink="/submitpage">Submit</a>


### PR DESCRIPTION
Resolves #23 

Before, the homepage button link would throw a 404 error, but now it's been fixed such that the link now routes to the homepage.