### PR TITLE
Handle validation of posted text #7

### DIFF
--- a/Server/app.go
+++ b/Server/app.go
@@ -118,6 +118,18 @@ func (a *App) addText(w http.ResponseWriter, r *http.Request) {
 		sendErr(w, http.StatusBadRequest, "Cannot post text with title")
 		return
 	}
+	if len(text.Title) > 260 {
+		sendErr(w, http.StatusBadRequest, "Cannot post text title of more than 260 characters")
+		return
+	}
+	if len(text.Body) > 10000 {
+		sendErr(w, http.StatusBadRequest, "Cannot post text title of more than 10,000 characters")
+		return
+	}
+	if text.Expire_at != nil && text.Expire_at.Before(time.Now()) {
+		sendErr(w, http.StatusBadRequest, "Text expiry cannot be before current time")
+		return
+	}
 	err, id := postText(a.db, text)
 	if err != nil {
 		sendErr(w, http.StatusBadRequest, err.Error())


### PR DESCRIPTION
Resolves #7
The following constraints are added to texts:-

- The title cannot be more than 260 characters.
- The body cannot be more than 10,000 characters.
- The expire_at date of a text cannot be before the current time.