### PR TITLE
Use test db for testing #171

### DIFF
--- a/Server/get_db_release.go
+++ b/Server/get_db_release.go
@@ -1,0 +1,14 @@
+//go:build !testing
+
+package main
+
+import (
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func getDb() (*gorm.DB, error) {
+	db, err := gorm.Open(sqlite.Open("gorm.db"))
+	print("Main")
+	return db, err
+}

--- a/Server/get_db_testing.go
+++ b/Server/get_db_testing.go
@@ -1,0 +1,14 @@
+//go:build testing
+
+package main
+
+import (
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func getDb() (*gorm.DB, error) {
+	db, err := gorm.Open(sqlite.Open("test.db"))
+	print("testing")
+	return db, err
+}

--- a/Server/main.go
+++ b/Server/main.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 
 	"github.com/gorilla/mux"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 func main() {
 
-	db, err := gorm.Open(sqlite.Open("gorm.db"))
+	db, err := getDb()
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
resolves #171 
Now when we run 
```
go run -tags testing
```
the app will use a test db instead of the main db