### PR TITLE
#231 Checks if user is logged in to select the private tag for pastes

### DIFF
--- a/new_pastebin_frontend/src/app/submitpage/submitpage.component.html
+++ b/new_pastebin_frontend/src/app/submitpage/submitpage.component.html
@@ -48,9 +48,11 @@
               <mat-option #option1 [value]="'Public'" (click)="onChange('public', option1.selected)">
                 Public
               </mat-option>
-              <mat-option #option2 [value]="'Private'" (click)="onChange('private', option2.selected)">
-                Private
-              </mat-option>
+              <div *ngIf="logged===true">
+                <mat-option #option2 [value]="'Private'" (click)="onChange('private', option2.selected)">
+                  Private
+                </mat-option>
+              </div>
               <mat-option #option3 [value]="'Unlisted'" (click)="onChange('unlisted', option3.selected)">
                 Unlisted
               </mat-option>

--- a/new_pastebin_frontend/src/app/submitpage/submitpage.component.ts
+++ b/new_pastebin_frontend/src/app/submitpage/submitpage.component.ts
@@ -29,10 +29,12 @@ export class SubmitpageComponent implements OnInit {
   ) { }
   textModel = new Paste("","","","","","")
   tagGlobal: string="";
+  logged:boolean = false;
   title = new FormControl('', [Validators.required]);
   ngOnInit(): void {
     this.socialAuthService.authState.subscribe(user =>{
       this.socialUser = user;
+      this.logged = true;
       localStorage.setItem('UserID', user.id);
       // console.log("id: "+ user.id)
     })


### PR DESCRIPTION
Added an "if statement" that checks if the user is logged in. If the user is logged in, when creating a new paste, the user can choose the "Private" tag. If not logged in, only "Public" and "Unlisted" tags are shown. A logged in user gets all 3 options.

Resolves #231 