### PR TITLE
#246 Added userid to the pastestype metadata

### DIFF
--- a/new_pastebin_frontend/src/app/submitpage/submitpage.component.ts
+++ b/new_pastebin_frontend/src/app/submitpage/submitpage.component.ts
@@ -27,7 +27,7 @@ export class SubmitpageComponent implements OnInit {
     private socialAuthService: SocialAuthService,
     private router: Router
   ) { }
-  textModel = new Paste("","","","","","")
+  textModel = new Paste("","","","","","","")
   tagGlobal: string="";
   logged:boolean = false;
   title = new FormControl('', [Validators.required]);

--- a/new_pastebin_frontend/src/app/types/pastestype.ts
+++ b/new_pastebin_frontend/src/app/types/pastestype.ts
@@ -1,6 +1,7 @@
 export class Paste{
     constructor (
         public id: string,
+        public UserID: string,
         public title: string,
         public created_at: string,
         public expire_at: string,


### PR DESCRIPTION
Added the "UserID" parameter to the pastestype metadata. This way, we can connect the user's ID to the pastes they create via the Google Login API we used.

Resolves #246 