### PR TITLE
#284 previous pastes can now be displayed correctly. Fixed the bug

### DIFF
--- a/new_pastebin_frontend/src/app/textpage/textpage.component.ts
+++ b/new_pastebin_frontend/src/app/textpage/textpage.component.ts
@@ -48,21 +48,23 @@ export class TextpageComponent implements OnInit {
     console.log("storage ID: " + localStorage.getItem('userID'));
     this.activatedRoute.queryParams.subscribe(params => {
       let id = params['id'];
-    //   this.httpClient.post<any>("http://localhost:8080/api/getText",{"id":id}, {withCredentials: true}).subscribe(
-    //   response => {
-    //     this.paste = response
-    //     console.log(this.paste)
-    //   },
-    //   error => {
-    //     if(error.status == 404){
-    //       this.router.navigateByUrl('/404');
-    //     }
-    //     else if(error.status == 410){
-    //       this.router.navigateByUrl('/expiredpage');
-    //     }
-    //   }
-    // );
-    this.paste = this.map.get(id);
+      this.httpClient.post<any>("http://localhost:8080/api/getText",{"id":id}, {withCredentials: true}).subscribe(
+      response => {
+        this.paste = response
+        console.log(this.paste)
+      },
+      error => {
+        if(error.status == 404){
+          this.router.navigateByUrl('/404');
+        }
+        else if(error.status == 410){
+          this.router.navigateByUrl('/expiredpage');
+        }
+      }
+    );
+    if(!this.map.has(this.paste)){
+      this.paste = this.map.get(id);
+    }
     console.log(this.paste);
   });
     


### PR DESCRIPTION
Previous pastes are now showing correctly. The problem was because of the commented out code detailing the "getText" backend API route. With this, both previous and new pastes can be shown correctly.

Resolves #284 