### PR TITLE
#323 logged in user can now see their specific pastes

### DIFF
--- a/new_pastebin_frontend/src/app/viewpage/viewpage.component.ts
+++ b/new_pastebin_frontend/src/app/viewpage/viewpage.component.ts
@@ -36,10 +36,16 @@ export class ViewpageComponent implements OnInit {
     }
     this.getPastes();
     
-    this.socialAuthService.authState.subscribe(user =>{
-      this.socialUser = user;
-      console.log("user: " + user.email);
-    });
+    var loggedInStatus = JSON.parse(localStorage.getItem('loggedInStatus') || 'false');
+    if(loggedInStatus === true){
+      this.socialUser = JSON.parse(localStorage.getItem('user') || '{}');
+      console.log(this.socialUser);
+    }
+    
+    // this.socialAuthService.authState.subscribe(user =>{
+    //   this.socialUser = user;
+    //   console.log("user: " + user.email);
+    // });
   }
 
   getPastes(){


### PR DESCRIPTION
Logged in users can now see the pastes they've specifically created in the "View Pastes" tab. The issue was in getting the correct user from the logging in and now it's fixed.

Resolves #323 