### PR TITLE
#346 users can now create infinite lasting pastes

### DIFF
--- a/new_pastebin_frontend/src/app/submitpage/submitpage.component.ts
+++ b/new_pastebin_frontend/src/app/submitpage/submitpage.component.ts
@@ -64,7 +64,13 @@ export class SubmitpageComponent implements OnInit {
   }
     this.httpClient.post<any>("http://localhost:8080/api/submitText", payload, {withCredentials: true}).subscribe(
       response => {
-        let paste = new Paste(response.id, payload.userID, payload.title, new Date().toISOString(), (new Date(Date.parse(this.textModel.expire_at))).toISOString(), payload.body, payload.tag);
+        var paste;
+        if(this.textModel.expire_at != ""){
+          paste = new Paste(response.id, payload.userID, payload.title, new Date().toISOString(), (new Date(Date.parse(this.textModel.expire_at))).toISOString(), payload.body, payload.tag);
+        }
+        else{
+          paste = new Paste(response.id, payload.userID, payload.title, new Date().toISOString(), '', payload.body, payload.tag);
+        }
         this.map.set(response.id, paste);
         let jsonObject:any = {};  
         this.map.forEach((value, key) => {  


### PR DESCRIPTION
Previously, users could not create pastes without a definite expiry date. However now, the user doesn't have to set an expiry date and has the option to create an infinite lasting paste.

Resolves #346 